### PR TITLE
Change elmo-message-fetch-threshold default value to nil.

### DIFF
--- a/elmo/elmo.el
+++ b/elmo/elmo.el
@@ -45,7 +45,7 @@
 	(featurep 'berkeley-db))
     (require 'elmo-database))
 
-(defcustom elmo-message-fetch-threshold 30000
+(defcustom elmo-message-fetch-threshold nil
   "Fetch threshold."
   :type '(choice (integer :tag "Threshold (bytes)")
 		 (const :tag "No limitation" nil))


### PR DESCRIPTION
I think the default of this variable nowadays should be nil: most users do not want to be prompted if the size of the message is > 30K.
