### PR TITLE
lisp form '(aref timer 4)' is null in my emacs (24.3.50.1)

### DIFF
--- a/wl/wl-util.el
+++ b/wl/wl-util.el
@@ -831,7 +831,7 @@ This function is imported from Emacs 20.7."
 	   ;; Compute the time when this timer will run again, next.
 	   (next-time (timer-relative-time
 		       (list (aref timer 1) (aref timer 2) (aref timer 3))
-		       (* 5 (aref timer 4)) 0)))
+		       (* 5 wl-biff-check-interval) 0)))
       ;; If the activation time is far in the past,
       ;; skip executions until we reach a time in the future.
       ;; This avoids a long pause if Emacs has been suspended for hours.


### PR DESCRIPTION
I use wl-biff-check-interval replacing it to enable it work again.

What correct value should it be?
