### PR TITLE
elmo-file Fixes

### DIFF
--- a/elmo/elmo-file.el
+++ b/elmo/elmo-file.el
@@ -233,16 +233,14 @@
   (delq nil
 	(mapcar
 	 (lambda (file)
-	   (when (not (file-directory-p file))
-	     (concat
-	      file "/"
-	      (mapconcat
-	       'number-to-string
-	       (nth 5 (file-attributes (expand-file-name
-					file
-					(elmo-file-folder-file-path-internal
-					 folder))))
-	       ":"))))
+	   (let ((name (expand-file-name
+			file
+			(elmo-file-folder-file-path-internal folder))))
+	     (when (not (file-directory-p name))
+	       (concat
+		file "/"
+		(mapconcat 'number-to-string (nth 5 (file-attributes name))
+			   ":")))))
 	 (directory-files (elmo-file-folder-file-path-internal folder)))))
 
 (luna-define-method elmo-folder-exists-p ((folder elmo-file-folder))


### PR DESCRIPTION
This fixes elmo-file to the extent that it is usable for moving patches between a folder and a filesystem directory.  In particular, elmo-file no longer tags files without an extension as application/octet-stream, and searches now work.
