### PR TITLE
Use a period instead of percent sign when generating Message-ID.

### DIFF
--- a/wl/wl-util.el
+++ b/wl/wl-util.el
@@ -625,7 +625,7 @@ that `read' can handle, whenever this is possible."
 	     (string-match "\\`\\(.+\\)@\\([^@]+\\)\\'" string))
     (let ((local (match-string 1 string))
 	  (domain (match-string 2 string)))
-      (format "<%s%%%s@%s>"
+      (format "<%s.%s@%s>"
 	      (wl-unique-id)
 	      (if wl-message-id-hash-function
 		  (concat "%" (funcall wl-message-id-hash-function local))


### PR DESCRIPTION
We are currently using % to separate the user name in Message-IDs,
which requires URL-encoding and is inconvenient when pasting Message-IDs
into URLs.  Change this to a period.
