### PR TITLE
Require wl-util in wl-draft.

### DIFF
--- a/wl/ChangeLog
+++ b/wl/ChangeLog
@@ -1,3 +1,7 @@
+2014-07-03  Juliusz Chroboczek  <jch@pps.univ-paris-diderot.fr>
+
+	* wl-draft.el: Require wl-util, since we're using macros from there.
+
 2014-06-09  David Maus  <dmaus@ictsoc.de>
 
 	* wl-draft.el (wl-draft-do-fcc): Open fcc folder before appending

--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -38,6 +38,7 @@
 (require 'timezone nil t)
 (require 'std11)
 (require 'eword-encode)
+(require 'wl-util)
 (require 'wl-vars)
 
 (defvar x-face-add-x-face-version-header)


### PR DESCRIPTION
Wl-draft uses macros from wl-util, it cannot be compiled without it.
