### PR TITLE
Protect against overwriting match data in elmo-pipe folder-initialize.

### DIFF
--- a/elmo/ChangeLog
+++ b/elmo/ChangeLog
@@ -1,3 +1,8 @@
+2014-07-07  Juliusz Chroboczek  <jch@pps.univ-paris-diderot.fr>
+
+	* elmo-pipe.el (elmo-folder-initialize): Protect against
+	overwriting match data.
+
 2014-06-11  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* elmo-date.el (elmo-time-less-p): Use car-less-than-car.

--- a/elmo/elmo-pipe.el
+++ b/elmo/elmo-pipe.el
@@ -44,14 +44,13 @@
 (luna-define-method elmo-folder-initialize ((folder elmo-pipe-folder)
 					    name)
   (when (string-match "^\\([^|]*\\)|\\(:?\\)\\(.*\\)$" name)
-    (elmo-pipe-folder-set-src-internal folder
-				       (elmo-get-folder
-					(match-string 1 name)))
-    (elmo-pipe-folder-set-dst-internal folder
-				       (elmo-get-folder
-					(match-string 3 name)))
-    (elmo-pipe-folder-set-copy-internal folder
-					(string= ":" (match-string 2 name))))
+    ;; elmo-get-folder might overwrite our match data
+    (let ((src (match-string 1 name))
+          (dst (match-string 3 name))
+          (copy (string= ":" (match-string 2 name))))
+      (elmo-pipe-folder-set-src-internal folder (elmo-get-folder src))
+      (elmo-pipe-folder-set-dst-internal folder (elmo-get-folder dst))
+      (elmo-pipe-folder-set-copy-internal folder copy)))
   (elmo-pipe-connect-signals folder (elmo-pipe-folder-dst-internal folder))
   folder)
 


### PR DESCRIPTION
Probably not triggered by stock Wanderlust, but triggered by some code of mine.
