### PR TITLE
Add support for X-GM-RAW search attribute (gmail)

### DIFF
--- a/elmo/elmo-imap4.el
+++ b/elmo/elmo-imap4.el
@@ -2349,7 +2349,7 @@ Returns a list of UIDs."
 (defun elmo-imap4-search-generate-vector (folder filter from-msgs)
   (let ((search-key (elmo-filter-key filter))
 	(imap-search-keys '("bcc" "body" "cc" "from" "subject" "to"
-			    "larger" "smaller" "flag")))
+			    "larger" "smaller" "flag" "x-gm-raw")))
     (cond
      ((string= "last" search-key)
       (let ((numbers (or from-msgs (elmo-folder-list-messages folder)))


### PR DESCRIPTION
This allows a user to search via the `X-GM-RAW` search attribute in gmail if they have `"X-GM-RAW"` in `wl-additional-search-condition-fields`. See https://developers.google.com/gmail/imap_extensions#extension_of_the_search_command_x-gm-raw for more.

This is part of some overall improvements to Wanderlust's search UI that I am working on.
