### PR TITLE
Use elmo-list-diff instead of elmo-list-difference

### DIFF
--- a/elmo/ChangeLog
+++ b/elmo/ChangeLog
@@ -1,3 +1,10 @@
+2014-11-02  Erik Hetzner <egh@e6h.org>
+
+	* elmo-imap.el (elmo-imap4-search-generate-vector): Do not use
+	elmo-list-difference, use faster elmo-list-diff instead.
+
+	* elmo-util.el (elmo-list-difference): Remove unused method.
+
 2014-10-19  David Maus  <dmaus@ictsoc.de>
 
 	* elmo-imap4.el (elmo-imap4-search-keys): New variable. Known IMAP

--- a/elmo/elmo-imap4.el
+++ b/elmo/elmo-imap4.el
@@ -2384,8 +2384,9 @@ Returns a list of UIDs."
 		numbers)))
      ((string= "first" search-key)
       (let ((numbers (or from-msgs (elmo-folder-list-messages folder))))
-	(elmo-list-difference
-	 (nthcdr (string-to-number (elmo-filter-value filter)) numbers) numbers)))
+        (cadr (elmo-list-diff
+               (nthcdr (string-to-number (elmo-filter-value filter)) numbers)
+               numbers))))
      ((string= "flag" search-key)
       (list nil
 	    (if (eq (elmo-filter-type filter) 'unmatch) "not " "")

--- a/elmo/elmo-util.el
+++ b/elmo/elmo-util.el
@@ -898,14 +898,6 @@ the directory becomes empty after deletion."
 	  (delete-directory path) ; should be removed if empty.
 	  ))))
 
-(defun elmo-list-difference (l1 l2)
-  "Return a list from L2 in which each element is not a member of L1."
-  (let (result)
-    (dolist (element l2)
-      (if (not (memq element l1))
-	  (setq result (cons element result))))
-    (nreverse result)))
-
 (defun elmo-list-filter (l1 l2)
   "Return a list from L2 in which each element is a member of L1."
   (let (result)


### PR DESCRIPTION
@jeck pointed out that `elmo-list-difference` is quite slow. I have removed the only use of this function in the codebase, which does substantially speed up when searching an IMAP folder using the `first` field.
