### PR TITLE
set encoding for wl-ja.texi

### DIFF
--- a/doc/wl-ja.texi
+++ b/doc/wl-ja.texi
@@ -4,6 +4,7 @@
 @settitle Wanderlust -- Yet Another Message Interface On Emacsen --
 @c %**end of header
 @documentlanguage ja
+@documentencoding iso-2022-jp
 @include version.texi
 @synindex pg cp
 @finalout


### PR DESCRIPTION
Fix to allow `wl-ja.texi` to build with `texi2any`.
