### PR TITLE
Fix error running timer `wl-biff-event-handler'

### DIFF
--- a/wl/wl-util.el
+++ b/wl/wl-util.el
@@ -774,7 +774,7 @@ that `read' can handle, whenever this is possible."
       (if wl-biff-use-idle-timer
 	  (if (get 'wl-biff 'timer)
 	      (progn (timer-set-idle-time (get 'wl-biff 'timer)
-					  wl-biff-check-interval t)
+					  wl-biff-check-interval wl-biff-check-interval)
 		     (timer-activate-when-idle (get 'wl-biff 'timer)))
 	    (put 'wl-biff 'timer
 		 (run-with-idle-timer


### PR DESCRIPTION
Cf. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=768910

> Dear Maintainer,
>      I keep seeing timer errors from wl-biff:
> 
> ```
>  Error running timer `wl-biff-event-handler':
>     (wrong-type-argument number-or-marker-p t)
> ```
> 
> This is because t is passed to timer-set-idle-time instead of a number
> of seconds.
> 
> Here is a patch to fix it:
