### PR TITLE
wl-draft-mode: Use rebind to map wl-draft-highlight-and-recenter

### DIFF
--- a/wl/wl-e21.el
+++ b/wl/wl-e21.el
@@ -663,7 +663,8 @@ Special commands:
   (define-key wl-draft-mode-map "\C-c\C-c" 'wl-draft-send-and-exit)
   (define-key wl-draft-mode-map "\C-c\C-z" 'wl-draft-save-and-exit)
   (define-key wl-draft-mode-map "\C-c\C-k" 'wl-draft-kill)
-  (define-key wl-draft-mode-map "\C-l" 'wl-draft-highlight-and-recenter)
+  (define-key wl-draft-mode-map [remap recenter-top-bottom]
+    'wl-draft-highlight-and-recenter)
   (define-key wl-draft-mode-map "\C-i" 'wl-complete-field-body-or-tab)
   (define-key wl-draft-mode-map "\C-c\C-r" 'wl-draft-caesar-region)
   (define-key wl-draft-mode-map "\M-t" 'wl-toggle-plugged)

--- a/wl/wl-mule.el
+++ b/wl/wl-mule.el
@@ -154,7 +154,8 @@ Special commands:
   (define-key wl-draft-mode-map "\C-c\C-c" 'wl-draft-send-and-exit)
   (define-key wl-draft-mode-map "\C-c\C-z" 'wl-draft-save-and-exit)
   (define-key wl-draft-mode-map "\C-c\C-k" 'wl-draft-kill)
-  (define-key wl-draft-mode-map "\C-l"     'wl-draft-highlight-and-recenter)
+  (define-key wl-draft-mode-map [remap recenter-top-bottom]
+    'wl-draft-highlight-and-recenter)
   (define-key wl-draft-mode-map "\C-i"     'wl-complete-field-body-or-tab)
   (define-key wl-draft-mode-map "\C-c\C-r" 'wl-draft-caesar-region)
   (define-key wl-draft-mode-map "\M-t"     'wl-toggle-plugged)


### PR DESCRIPTION
If using C-l as a prefix key Wanderlust's draft mode won't work as it is
trying to bind C-l to wl-draft-highlight-and-recenter.  By rebinding the
default function associated with C-l, recenter-top-bottom, the key can
be used as a prefix and still work with Wanderlust.
