### PR TITLE
fix time format string for cites

### DIFF
--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -558,7 +558,7 @@ Note: default value follows RFC2822."
   :group 'wl-draft)
 
 (defcustom wl-default-draft-cite-date-format-string
-  "On %a, %e %M %Y at %T %Z"
+  "On %a, %e %b %Y at %T %Z"
   "*Format string to use for first line of citation in `wl-default-draft-cite'.
 The value is passed to `format-time-string'."
   :type 'string


### PR DESCRIPTION
Sorry, I was sloppy with my time format string and used `%M` (minute) when I meant `%b` (month).