### PR TITLE
Move messages to lost+found when clearing queue

### DIFF
--- a/elmo/ChangeLog
+++ b/elmo/ChangeLog
@@ -1,3 +1,8 @@
+2015-05-15  Erik Hetzner  <egh@e6h.org>
+
+	* elmo-dop.el (elmo-dop-queue-flush): Move messages to
+	`elmo-lost+found-folder' when clearing queue, do not delete them.
+
 2014-11-29  David Maus  <dmaus@ictsoc.de>
 
 	* elmo-imap4.el (elmo-imap4-search-generate-vector): Provide

--- a/elmo/elmo-dop.el
+++ b/elmo/elmo-dop.el
@@ -159,10 +159,11 @@ Saved queue is old version(2.6).  Clear all pending operations? ")
 	      (while queue
 		(when (eq (elmo-dop-queue-method (car queue))
 			  'elmo-folder-append-buffer-dop-delayed)
-		  (elmo-folder-delete-messages
+		  (elmo-folder-move-messages
 		   (elmo-dop-spool-folder
 		    (elmo-get-folder (elmo-dop-queue-fname (car queue))))
-		   (list (nth 1 (elmo-dop-queue-arguments (car queue))))))
+		   (list (nth 1 (elmo-dop-queue-arguments (car queue))))
+		   (elmo-get-folder elmo-lost+found-folder)))
 		(setq elmo-dop-queue (delq (car queue) elmo-dop-queue))
 		(setq queue (cdr queue)))
 	      (message "Pending operations are cleared.")


### PR DESCRIPTION
See http://news.gmane.org/gmane.mail.wanderlust.general

After conversation with Adam, it turns out that this was the issue:

>> I see what happened now.
>>
>> 1. I tried to refile a message
>> 2. Pressed x, it reported auto plugged-of folder
>> 3. Pressed x again - refiled without issue
>> 4. Remembers the refiles even between restarts but offers to clear
>>     pending operations and then the messages are lost - neither refiled,
>>     nor in the original location.

This corrects at least part of the issue by moving messages to `elmo-lost+found-folder` rather than simply deleting them when clearing queue.