### PR TITLE
Move to beginning of line in wl-draft-default-jit-highlight.

### DIFF
--- a/wl/ChangeLog
+++ b/wl/ChangeLog
@@ -1,3 +1,8 @@
+2015-05-24  Juliusz Chroboczek  <jch@pps.univ-paris-diderot.fr>
+
+	* wl-draft.el (wl-draft-default-jit-highlight): Move to BOL before
+	fontifying, this fixes Emacs 25.
+
 2015-03-08  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* wl.el (wl-check-environment): Checking Message-ID part is almost

--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -2706,6 +2706,8 @@ This is ignored when wl-draft-jit-highlight is set."
 
 (defun wl-draft-default-jit-highlight (start end)
   (goto-char start)
+  (beginning-of-line)
+  (setq start (point))
   (let ((in-header (wl-draft-point-in-header-p)))
     ;; check for multi-line header, extend region if necessary
     (when in-header


### PR DESCRIPTION
Under Emacs 25, this function is not necessarily called at BOL.