### PR TITLE
Typo in IMAP elmo-fetch-message-field

### DIFF
--- a/elmo/ChangeLog
+++ b/elmo/ChangeLog
@@ -2,6 +2,8 @@
 
 	* elmo-imap4.el (elmo-message-fetch-field): Fix typo.
 
+	* elmo.el (elmo-message-fetch-field): Improve documentation.
+
 2015-05-17  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* elmo-rss.el (elmo-rss-format-message): Use USEC of current-time

--- a/elmo/ChangeLog
+++ b/elmo/ChangeLog
@@ -1,3 +1,7 @@
+2015-05-24  Juliusz Chroboczek  <jch@pps.univ-paris-diderot.fr>
+
+	* elmo-imap4.el (elmo-message-fetch-field): Fix typo.
+
 2015-05-17  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* elmo-rss.el (elmo-rss-format-message): Use USEC of current-time

--- a/elmo/elmo-imap4.el
+++ b/elmo/elmo-imap4.el
@@ -2978,7 +2978,7 @@ time."
          (elmo-imap4-send-command-wait session
                                        (concat
                                         (if elmo-imap4-use-uid
-                                            "uid")
+                                            "uid ")
                                         (format
                                          "fetch %s (body.peek[header.fields (%s)])"
                                          number field)))

--- a/elmo/elmo.el
+++ b/elmo/elmo.el
@@ -670,7 +670,7 @@ If second optional argument UNREAD is non-nil, message is not flaged as read.
 Returns non-nil if fetching was succeed.")
 
 (luna-define-generic elmo-message-fetch-field (folder number field)
-  "Fetch a message field value.
+  "Fetch a message field value bypassing cache, return nil if not easily available.
 FOLDER is the ELMO folder structure.
 NUMBER is the number of the message in the FOLDER.
 FIELD is a symbol of the field name.")


### PR DESCRIPTION
    diff -u elmo-imap4.el~ elmo-imap4.el
    --- elmo-imap4.el~	2015-05-19 21:53:16.310278029 +0200
    +++ elmo-imap4.el	2015-05-23 17:49:00.359532521 +0200
    @@ -2978,7 +2978,7 @@
              (elmo-imap4-send-command-wait session
                                            (concat
                                             (if elmo-imap4-use-uid
    -                                            "uid")
    +                                            "uid ")
                                             (format
                                              "fetch %s (body.peek[header.fields (%s)])"
                                              number field)))
