### PR TITLE
Provide default values to `read-buffer'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2016-02-24  Erik Hetzner  <egh@e6h.org>
+
+	* wl-draft.wl (wl-draft-mimic-kill-buffer): Provide default to
+	`read-buffer'
+
+	* wl-folder.wl (wl-folder-mimic-kill-buffer): Provide default to
+	`read-buffer'
+
 2015-12-28  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* doc/wl.texi, doc/wl-ja.texi: Describe

--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -1495,9 +1495,10 @@ If KILL-WHEN-DONE is non-nil, current draft buffer is killed"
 (defun wl-draft-mimic-kill-buffer ()
   "Kill the current (draft) buffer with query."
   (interactive)
-  (let ((bufname (read-buffer (format "Kill buffer: (default %s) "
-				      (buffer-name))))
-	wl-draft-use-frame)
+  (let* ((default (buffer-name))
+	 (bufname (read-buffer (format "Kill buffer: (default %s) " default)
+			       default))
+	 wl-draft-use-frame)
     (if (or (not bufname)
 	    (string-equal bufname "")
 	    (string-equal bufname (buffer-name)))

--- a/wl/wl-folder.el
+++ b/wl/wl-folder.el
@@ -2847,9 +2847,10 @@ Call `wl-summary-write-current-folder' with current folder name."
 (defun wl-folder-mimic-kill-buffer ()
   "Kill the current (Folder) buffer with query."
   (interactive)
-  (let ((bufname (read-buffer (format "Kill buffer: (default %s) "
-				      (buffer-name))))
-	wl-interactive-exit)
+  (let* ((default (buffer-name))
+	 (bufname (read-buffer (format "Kill buffer: (default %s) " default)
+			       default))
+         wl-interactive-exit)
     (if (or (not bufname)
 	    (string-equal bufname "")
 	    (string-equal bufname (buffer-name)))


### PR DESCRIPTION
* wl-draft.wl (wl-draft-mimic-kill-buffer): Provide default to
`read-buffer'

* wl-folder.wl (wl-folder-mimic-kill-buffer): Provide default to
`read-buffer'

See also https://github.com/wanderlust/semi/pull/14. This helps out with `ido-ubiquitous`.