### PR TITLE
Consider `wl-draft-use-frame' customization in `compose-mail' interface

### DIFF
--- a/wl/ChangeLog
+++ b/wl/ChangeLog
@@ -1,3 +1,8 @@
+2016-06-11  David Maus  <dmaus@dmaus.name>
+
+	* wl-draft.el (wl-user-agent-compose): Consider
+	`wl-draft-use-frame' customization.
+
 2016-04-30  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* wl.el (wl-init): Add `elmo-quit' into kill-emacs-hook.

--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -2596,7 +2596,7 @@ been implemented yet.  Partial support for SWITCH-FUNCTION now supported."
   ;; protect these -- to and subject get bound at some point, so it looks
   ;; to be necessary to protect the values used w/in
   (let ((wl-user-agent-headers-and-body-alist other-headers)
-	(wl-draft-use-frame (eq switch-function 'switch-to-buffer-other-frame))
+	(wl-draft-use-frame (or wl-draft-use-frame (eq switch-function 'switch-to-buffer-other-frame)))
 	(wl-draft-buffer-style switch-function)
 	tem)
     (if to


### PR DESCRIPTION
- wl-draft.el (wl-user-agent-compose): Consider `wl-draft-use-frame'
  customization.

Fix #120
