### PR TITLE
Searches don't work with elmo-rss

### DIFF
--- a/elmo/elmo-rss.el
+++ b/elmo/elmo-rss.el
@@ -389,6 +389,10 @@ Setting this to true will annoy the pedants."
 (luna-define-method elmo-folder-local-p ((folder elmo-rss-folder))
   nil)
 
+(luna-define-method elmo-message-use-cache-p ((folder elmo-rss-folder)
+                                              number)
+  t)
+
 (luna-define-method elmo-folder-close-internal :after ((folder elmo-rss-folder))
   (elmo-rss-folder-set-downloaded-internal folder nil)
   (elmo-rss-folder-set-entries-internal folder nil)


### PR DESCRIPTION
Neither `?` nor `V` works with elmo-rss folders.  Since I'm the author of elmo-rss, I guess it's my job to fix it, but unfortunately I have no idea what the issue is.

I'll be grateful for help.
