### PR TITLE
fix my previous commit to elmo-get-passwd

### DIFF
--- a/elmo/ChangeLog
+++ b/elmo/ChangeLog
@@ -1,3 +1,8 @@
+2016-11-14  Piotr Trojanek  <piotr.trojanek@gmail.com>
+
+	* elmo-util.el (elmo-get-passwd): fix previous change to this
+	routine, where passwords were only appended to non-empty alists.
+
 2016-11-09  Piotr Trojanek  <piotr.trojanek@gmail.com>
 
 	* elmo-util.el (elmo-get-passwd): while new password was appended

--- a/elmo/elmo-util.el
+++ b/elmo/elmo-util.el
@@ -616,11 +616,11 @@ Return value is a cons cell of (STRUCTURE . REST)"
     (if pair
 	(elmo-base64-decode-string (cdr pair))
       (setq pass (read-passwd (format "Password for %s: " key)))
-      ;; setq and append would make the original list with passwords a garbage;
-      ;; nconc, unlike append, does not copy the original list
-      (nconc elmo-passwd-alist
-             (list (cons key
-                         (elmo-base64-encode-string pass))))
+      ;; put key and passwd at the front of the alist
+      (setq elmo-passwd-alist
+            (cons (cons key
+                        (elmo-base64-encode-string pass))
+                  elmo-passwd-alist))
       (if elmo-passwd-life-time
 	  (run-with-timer elmo-passwd-life-time nil
 			  `(lambda () (elmo-remove-passwd ,key))))


### PR DESCRIPTION
Previous change to elmo-get-passwd replaced append with nconc, but the side
effect of nconc is only visible when the extended list is non-empty. Instead
of fixing by storing the nconc result with setq use plain cons to put new
password at the front (and not at the end, as it was before).

Putting new data at the front should make no difference to an alist: there
is no item with the same key (because if it is then it is returned earlier).
Also, putting at the front is marginally faster (because we do not have to
re-traverse the alist to get to its end).