### PR TITLE
Improve wl-biff mail checking/notification

### DIFF
--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -887,6 +887,10 @@ The cursor point is located at top of the body.")
   "A hook called when a biff-notification is invoked.")
 (defvar wl-biff-unnotify-hook nil
   "A hook called when a biff-notification is removed.")
+(defvar wl-biff-new-mail-functions nil
+  "A hook called when `wl-biff-notify' found non-zero new
+  mails. The hook functions receive the number of new mails as
+  the first argument.")
 (defvar wl-auto-check-folder-pre-hook nil
   "A hook called before auto check folders.")
 (defvar wl-auto-check-folder-hook nil
@@ -2251,14 +2255,19 @@ every intervals specified by `wl-biff-check-interval'."
   :type 'number
   :group 'wl-setting)
 
-(defcustom wl-biff-check-delay 0
-  "After interval specified by `wl-biff-check-interval', automatically checking new mail will start when Emacs keeps idle longer than specified seconds by this varaible.
-It has no effect on XEmacs or for the case which `wl-biff-use-idle-timer' is non-nil."
+(defcustom wl-biff-check-idle-delay nil
+  "Number of seconds that Emacs has to be idle before checking
+for new mail. If nil, Emacs will check for new mail every
+`wl-biff-check-interval' seconds whether Emacs is idle or
+not. This setting does nothing when `wl-biff-use-idle-timer' is
+non-nil."
   :type 'number
   :group 'wl-setting)
 
 (defcustom wl-biff-use-idle-timer nil
-  "Non-nil means that Emacs will not use normal timer for wl-biff."
+  "Non-nil means that Emacs will use the idle timer to check for
+new mail. The idle timer fires only once after Emacs becomes
+idle, after `wl-biff-check-interval' seconds."
   :type 'boolean
   :group 'wl-setting)
 


### PR DESCRIPTION
This pull request addresses the following issues:
- WL should check new mail periodically when Emacs is idle, but not disturb user when Emacs is not idle. `wl-biff-use-idle-timer` is not sufficient for this.
- WL should be able to update Summary views when new mail arrives. `wl-biff-notify-hook` is not sufficient for this.

See also discussion on wl-en mailing list.

Recommended use:
```elisp
  ;; Check mail every 60 seconds
  (setq wl-biff-check-interval 60)
  ;; ... but only when idle for 180 seconds
  (setq wl-biff-check-idle-delay 180)
  ;; Don't use idle timer, it fires only once after Emacs
  ;; becomes idle
  (setq wl-biff-use-idle-timer nil)
```

Details:
- Adds hook `wl-biff-new-mail-functions` to allow updating summary buffers from wl-biff-notify.
- Renames `wl-biff-check-delay` to `wl-biff-check-idle-delay`. This more closely tracks the meaning.
- Fix tight loop when `wl-biff-use-idle-timer` is set to t.