### PR TITLE
Add support for horizontally split draft buffer window: split-horiz

### DIFF
--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -2422,7 +2422,13 @@ Automatically applied in draft sending time."
       len)))
 
 (defun wl-jump-to-draft-buffer (&optional arg)
-  "Jump to the first of the buffers that are in `wl-draft-mode'."
+  "Jump to the first of the buffers that are in `wl-draft-mode',
+unless called from a draft buffer, in which case switch to the
+next one.  If called from a buffer in `wl-summary-mode' then
+first try to display the message at the point.  Apply the
+`wl-draft-buffer-style' rules to display the selected draft
+buffer.  If ARG is not nil then call `wl-jump-to-draft-folder'
+instead."
   (interactive "P")
   (if arg
       (wl-jump-to-draft-folder)
@@ -2430,7 +2436,7 @@ Automatically applied in draft sending time."
 	  buf)
       (cond
        ((null draft-bufs)
-	(message "No draft buffer exist."))
+	(message "No draft buffers exist."))
        (t
 	(setq draft-bufs
 	      (sort (mapcar 'buffer-name draft-bufs)
@@ -2449,8 +2455,16 @@ Automatically applied in draft sending time."
 	  (if buf-win
 	      (pop-to-buffer buf)
 	    ;;
-	    ;; XXX we have no way now to know if the draft was a reply or a new
-	    ;; message, so just assume it was a new message for now....
+	    ;; we have no way now to know whether the draft buffer was opened as
+	    ;; a reply or as a new message, so just assume it was a new message
+	    ;; and ignore wl-draft-reply-buffer-style, though note above that if
+	    ;; called from the summary buffer then we have displayed the current
+	    ;; message, implying for some interpretations that we might be a
+	    ;; writing a reply to the current summary message -- on the other
+	    ;; hand this is also useful to write a new message only using the
+	    ;; current summary message as a reference, not a true reply -- one
+	    ;; would never call this function from the summary buffer, while
+	    ;; viewing a message, and expect the viewed message to disappear.
 	    ;;
 	    (case wl-draft-buffer-style
 	      (split

--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -2450,39 +2450,40 @@ instead."
 	  (wl-summary-toggle-disp-msg 'on)
 	  (save-excursion
 	    (wl-summary-set-message-buffer-or-redisplay))
-	  (wl-message-select-buffer wl-message-buffer))
-	(let ((buf-win (get-buffer-window buf)))
-	  (if buf-win
-	      (pop-to-buffer buf)
-	    ;;
-	    ;; we have no way now to know whether the draft buffer was opened as
-	    ;; a reply or as a new message, so just assume it was a new message
-	    ;; and ignore wl-draft-reply-buffer-style, though note above that if
-	    ;; called from the summary buffer then we have displayed the current
-	    ;; message, implying for some interpretations that we might be a
-	    ;; writing a reply to the current summary message -- on the other
-	    ;; hand this is also useful to write a new message only using the
-	    ;; current summary message as a reference, not a true reply -- one
-	    ;; would never call this function from the summary buffer, while
-	    ;; viewing a message, and expect the viewed message to disappear.
-	    ;;
-	    (case wl-draft-buffer-style
-	      (split
-	       (split-window-vertically)
-	       (other-window 1)
-	       (switch-to-buffer buf))
-	      (split-horiz
-	       (split-window-horizontally)
-	       (other-window 1)
-	       (switch-to-buffer buf))
-	      (keep
-	       (switch-to-buffer buf))
-	      (full
-	       (delete-other-windows)
-	       (switch-to-buffer buf))
-	      (t (if (functionp wl-draft-buffer-style)
-		     (funcall wl-draft-buffer-style buf)
-		   (error "Invalid value for wl-draft-buffer-style")))))))))))
+	  (wl-message-select-buffer wl-message-buffer)
+	  (let ((buf-win (get-buffer-window buf)))
+	    (if buf-win
+		(pop-to-buffer buf)
+	      ;;
+	      ;; we have no way at this point to know whether the draft buffer
+	      ;; was opened as a reply or as a new message, so just assume it
+	      ;; was a new message and ignore wl-draft-reply-buffer-style,
+	      ;; though note above that if called from the summary buffer then
+	      ;; we have displayed the current message, implying for some
+	      ;; interpretations that we might be a writing a reply to the
+	      ;; current summary message -- on the other hand this is also
+	      ;; useful to write a new message only using the current summary
+	      ;; message as a reference, not a true reply -- one would never
+	      ;; call this function from the summary buffer, while viewing a
+	      ;; message, and expect the viewed message to disappear.
+	      ;;
+	      (case wl-draft-buffer-style
+		(split
+		 (split-window-vertically)
+		 (other-window 1)
+		 (switch-to-buffer buf))
+		(split-horiz
+		 (split-window-horizontally)
+		 (other-window 1)
+		 (switch-to-buffer buf))
+		(keep
+		 (switch-to-buffer buf))
+		(full
+		 (delete-other-windows)
+		 (switch-to-buffer buf))
+		(t (if (functionp wl-draft-buffer-style)
+		       (funcall wl-draft-buffer-style buf)
+		     (error "Invalid value for wl-draft-buffer-style"))))))))))))
 
 (defun wl-jump-to-draft-folder ()
   (let ((msgs (reverse (elmo-folder-list-messages (wl-draft-get-folder))))

--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -1760,16 +1760,16 @@ If KILL-WHEN-DONE is non-nil, current draft buffer is killed"
      ;; XXX whether toggling off the message display here makes sense or not is
      ;; higly questionable!  If it does for anyone then arguably it should split
      ;; the summary window with the same ratio as with `wl-message-window-size'.
-     (when (eq major-mode 'wl-summary-mode)
-       (wl-summary-toggle-disp-msg 'off))
+     (if (eq major-mode 'wl-summary-mode)
+	 (wl-summary-toggle-disp-msg 'off))
      (split-window-vertically)
      (other-window 1)
      (switch-to-buffer buffer))
     (msg-split
-     (if (eq major-mode 'wl-folder-mode)
-	 (progn
-	   (wl-folder-jump-to-previous-summary)
-	   (set-buffer (get-buffer wl-summary-buffer-name))))
+     (when (and (eq major-mode 'wl-folder-mode)
+		(get-buffer-window (car (wl-collect-summary))))
+       (wl-folder-jump-to-previous-summary)
+       (set-buffer (get-buffer wl-summary-buffer-name)))
      (if wl-summary-buffer-disp-msg
 	 (wl-summary-jump-to-current-message))
      (split-window-vertically)
@@ -1779,16 +1779,16 @@ If KILL-WHEN-DONE is non-nil, current draft buffer is killed"
      (if (and (eq major-mode 'wl-folder-mode)
 	      (get-buffer-window (car (wl-collect-summary))))
 	 (wl-folder-jump-to-previous-summary))
-     (when (eq major-mode 'wl-summary-mode)
-       (wl-summary-toggle-disp-msg 'off))
+     (if (eq major-mode 'wl-summary-mode)
+	 (wl-summary-toggle-disp-msg 'off))
      (split-window-horizontally)
      (other-window 1)
      (switch-to-buffer buffer))
     (msg-split-horiz
-     (if (eq major-mode 'wl-folder-mode)
-	 (progn
-	   (wl-folder-jump-to-previous-summary)
-	   (set-buffer (get-buffer wl-summary-buffer-name))))
+     (when (and (eq major-mode 'wl-folder-mode)
+		(get-buffer-window (car (wl-collect-summary))))
+       (wl-folder-jump-to-previous-summary)
+       (set-buffer (get-buffer wl-summary-buffer-name)))
      (if wl-summary-buffer-disp-msg
 	 (wl-summary-jump-to-current-message))
      (split-window-horizontally)

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -4261,14 +4261,7 @@ Return t if message exists."
 (defun wl-summary-write (folder)
   "Write a new draft from Summary."
   (interactive (list (wl-summary-buffer-folder-name)))
-  (let ((number (wl-summary-message-number)))
-    (when number
-      (save-excursion
-	(wl-summary-set-message-buffer-or-redisplay))
-      (wl-message-select-buffer wl-message-buffer)))
-  (wl-draft (list (cons 'To "")) nil nil nil nil folder)
-  (run-hooks 'wl-mail-setup-hook)
-  (mail-position-on-field "To"))
+  (wl-draft (list (cons 'To "")) nil nil nil nil folder))
 
 (defvar wl-summary-write-current-folder-functions
   '(wl-folder-get-newsgroups

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -4237,10 +4237,9 @@ Return t if message exists."
 	     nil)))))
 
 (defun wl-summary-reply (&optional arg without-setup-hook)
-  "Reply to current message. See also `wl-draft-reply'."
+  "Reply to the current message. See also `wl-draft-reply'."
   (interactive "P")
-  (let ((folder wl-summary-buffer-elmo-folder)
-	(number (wl-summary-message-number))
+  (let ((number (wl-summary-message-number))
 	(summary-buf (current-buffer))
 	(winconf (current-window-configuration))
 	mes-buf)
@@ -4262,6 +4261,11 @@ Return t if message exists."
 (defun wl-summary-write (folder)
   "Write a new draft from Summary."
   (interactive (list (wl-summary-buffer-folder-name)))
+  (let ((number (wl-summary-message-number)))
+    (when number
+      (save-excursion
+	(wl-summary-set-message-buffer-or-redisplay))
+      (wl-message-select-buffer wl-message-buffer)))
   (wl-draft (list (cons 'To "")) nil nil nil nil folder)
   (run-hooks 'wl-mail-setup-hook)
   (mail-position-on-field "To"))

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -4261,7 +4261,10 @@ Return t if message exists."
 (defun wl-summary-write (folder)
   "Write a new draft from Summary."
   (interactive (list (wl-summary-buffer-folder-name)))
-  (wl-draft (list (cons 'To "")) nil nil nil nil folder))
+  (wl-draft (list (cons 'To "")) nil nil nil nil folder)
+  ;; wl-draft only does these if called `interactive-p'
+  (run-hooks 'wl-mail-setup-hook)
+  (mail-position-on-field "To"))
 
 (defvar wl-summary-write-current-folder-functions
   '(wl-folder-get-newsgroups

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -4028,7 +4028,7 @@ Return t if message exists."
       (save-window-excursion
 	(while mlist
 	  (set-buffer summary-buf)
-	  (delete-other-windows)
+	  (delete-other-windows)	; xxx this may be bad!
 	  (wl-summary-jump-to-msg (car mlist))
 	  (wl-summary-redisplay)
 	  (set-buffer draft-buf)

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -4028,7 +4028,7 @@ Return t if message exists."
       (save-window-excursion
 	(while mlist
 	  (set-buffer summary-buf)
-	  (delete-other-windows)	; xxx this may be bad!
+	  (delete-other-windows)
 	  (wl-summary-jump-to-msg (car mlist))
 	  (wl-summary-redisplay)
 	  (set-buffer draft-buf)

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -1510,24 +1510,34 @@ of `wl-draft-config-alist'."
   :group 'wl-draft
   :group 'wl-pref)
 
-(defcustom wl-draft-buffer-style 'full
-  "Style of draft buffer except for `wl-summary-reply' and `wl-summary-forward'
-'keep is to use current window, 'full is to use full frame window and
-'split is to split current window.
-If it is a function, it is called with the draft buffer as an argument."
+(defcustom wl-draft-buffer-style 'keep
+  "Style of draft buffer for writing new messages (i.e. except
+  for `wl-summary-reply' and `wl-summary-forward').
+
+'keep will use the current window for the new message,
+'full will use a full frame window,
+'split will split current window vertically (top-to-bottom), and
+'split-horiz will split the current window horizontally (side-by-side).
+If a function is given, it is called with the draft buffer as an argument."
   :type '(choice (const :tag "Keep window" keep)
-		 (const :tag "Split window" split)
+		 (const :tag "Split window vertically" split)
+		 (const :tag "Split window horizontally" split-horiz)
 		 (const :tag "Full window" full)
 		 (sexp :tag "Use Function"))
   :group 'wl-draft)
 
+;; ideally this should default to split-horiz if message window's width is > 144 or so
 (defcustom wl-draft-reply-buffer-style 'split
   "Style of draft buffer for `wl-summary-reply' and `wl-summary-forward'
-'keep is to use message buffer window, 'full is to use full frame window and
-'split is to split message buffer window.
-If it is a function, it is called with the draft buffer as an argument."
+
+'keep will use the existing message buffer window for the reply,
+'full will use a full frame window,
+'split will split message buffer window vertically (top-to-bottom), and
+'spilt-horiz will split the message window horizontally (side-by-side).
+If a function is given, it is called with the draft buffer as an argument."
   :type '(choice (const :tag "Keep window" keep)
-		 (const :tag "Split window" split)
+		 (const :tag "Split window vertically" split)
+		 (const :tag "Split window horizontally" split-horiz)
 		 (const :tag "Full window" full)
 		 (sexp :tag "Use Function"))
   :group 'wl-draft)

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -1512,13 +1512,21 @@ of `wl-draft-config-alist'."
 
 (defcustom wl-draft-buffer-style 'keep
   "Style of draft buffer for writing new messages (i.e. except
-  for `wl-summary-reply' and `wl-summary-forward').
+for `wl-summary-reply' and `wl-summary-forward').
 
 'keep will use the current window for the new message,
 'full will use a full frame window,
 'split will split current window vertically (top-to-bottom), and
+'msg-split will split the message buffer window vertically (top-to-bottom),
 'split-horiz will split the current window horizontally (side-by-side).
-If a function is given, it is called with the draft buffer as an argument."
+'msg-spilt-horiz will split the message window horizontally (side-by-side).
+If a function is given, it is called with the draft buffer as an
+argument.
+For 'split, 'msg-split, 'split-horiz, and 'msg-split-horiz if the
+current window is the folder window, and the summary window is
+visible, then the summary window is visited (with
+`wl-folder-jump-to-previous-summary') before any action is
+taken."
   :type '(choice (const :tag "Keep window" keep)
 		 (const :tag "Split window vertically" split)
 		 (const :tag "Split window horizontally" split-horiz)
@@ -1527,16 +1535,24 @@ If a function is given, it is called with the draft buffer as an argument."
   :group 'wl-draft)
 
 (defcustom wl-draft-reply-buffer-style 'split
-  "Style of draft buffer for `wl-summary-reply' and `wl-summary-forward'
+  "Style of draft buffer for `wl-summary-reply' and `wl-summary-forward'.
 
 'keep will use the existing message buffer window for the reply,
 'full will use a full frame window,
-'split will split message buffer window vertically (top-to-bottom), and
-'spilt-horiz will split the message window horizontally (side-by-side).
-If a function is given, it is called with the draft buffer as an argument."
+'split will split the message window vertically (top-to-bottom),
+'spilt-horiz will split the message window horizontally (side-by-side), and
+If a function is given, it is called with the draft buffer as an
+argument.
+If the message window is not visible then the current window is used.
+For 'split and 'split-horiz if the current window is the folder
+window, and the summary window is visible, then the summary
+window is visited (with `wl-folder-jump-to-previous-summary')
+before any action is taken."
   :type '(choice (const :tag "Keep window" keep)
-		 (const :tag "Split window vertically" split)
-		 (const :tag "Split window horizontally" split-horiz)
+		 (const :tag "Split current window vertically" split)
+		 (const :tag "Split message window vertically" msg-split)
+		 (const :tag "Split current window horizontally" split-horiz)
+		 (const :tag "Split message window horizontally" msg-split-horiz)
 		 (const :tag "Full window" full)
 		 (sexp :tag "Use Function"))
   :group 'wl-draft)

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -1526,7 +1526,6 @@ If a function is given, it is called with the draft buffer as an argument."
 		 (sexp :tag "Use Function"))
   :group 'wl-draft)
 
-;; ideally this should default to split-horiz if message window's width is > 144 or so
 (defcustom wl-draft-reply-buffer-style 'split
   "Style of draft buffer for `wl-summary-reply' and `wl-summary-forward'
 

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -1510,7 +1510,7 @@ of `wl-draft-config-alist'."
   :group 'wl-draft
   :group 'wl-pref)
 
-(defcustom wl-draft-buffer-style 'keep
+(defcustom wl-draft-buffer-style 'full
   "Style of draft buffer for writing new messages (i.e. except
 for `wl-summary-reply' and `wl-summary-forward').
 

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -1510,9 +1510,8 @@ of `wl-draft-config-alist'."
   :group 'wl-draft
   :group 'wl-pref)
 
-(defcustom wl-draft-buffer-style 'full
-  "Style of draft buffer for writing new messages (i.e. except
-for `wl-summary-reply' and `wl-summary-forward').
+(defcustom wl-draft-reply-buffer-style 'split
+  "Style of draft buffer for `wl-summary-reply' and `wl-summary-forward'.
 
 'keep will use the current window for the new message,
 'full will use a full frame window,
@@ -1531,8 +1530,9 @@ before any action is taken."
 		 (sexp :tag "Use Function"))
   :group 'wl-draft)
 
-(defcustom wl-draft-reply-buffer-style 'split
-  "Style of draft buffer for `wl-summary-reply' and `wl-summary-forward'.
+(defcustom wl-draft-buffer-style 'full
+  "Style of draft buffer for writing new messages (i.e. except
+for `wl-summary-reply' and `wl-summary-forward').
 
 'keep will use the existing message buffer window for the reply,
 'full will use a full frame window,

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -1517,16 +1517,13 @@ for `wl-summary-reply' and `wl-summary-forward').
 'keep will use the current window for the new message,
 'full will use a full frame window,
 'split will split current window vertically (top-to-bottom), and
-'msg-split will split the message buffer window vertically (top-to-bottom),
 'split-horiz will split the current window horizontally (side-by-side).
-'msg-spilt-horiz will split the message window horizontally (side-by-side).
 If a function is given, it is called with the draft buffer as an
 argument.
-For 'split, 'msg-split, 'split-horiz, and 'msg-split-horiz if the
-current window is the folder window, and the summary window is
-visible, then the summary window is visited (with
-`wl-folder-jump-to-previous-summary') before any action is
-taken."
+For 'split and 'split-horiz if the current window is the folder
+window, and the summary window is visible, then the summary
+window is visited (with `wl-folder-jump-to-previous-summary')
+before any action is taken."
   :type '(choice (const :tag "Keep window" keep)
 		 (const :tag "Split window vertically" split)
 		 (const :tag "Split window horizontally" split-horiz)
@@ -1540,14 +1537,18 @@ taken."
 'keep will use the existing message buffer window for the reply,
 'full will use a full frame window,
 'split will split the message window vertically (top-to-bottom),
+'msg-split will split the message buffer window vertically (top-to-bottom),
 'spilt-horiz will split the message window horizontally (side-by-side), and
+'msg-spilt-horiz will split the message window horizontally (side-by-side).
 If a function is given, it is called with the draft buffer as an
 argument.
-If the message window is not visible then the current window is used.
-For 'split and 'split-horiz if the current window is the folder
-window, and the summary window is visible, then the summary
-window is visited (with `wl-folder-jump-to-previous-summary')
-before any action is taken."
+If the message window is not visible then the current window is
+used.
+For 'split, 'msg-split, 'split-horiz, and 'msg-split-horiz if the
+current window is the folder window, and the summary window is
+visible, then the summary window is visited (with
+`wl-folder-jump-to-previous-summary') before any action is
+taken."
   :type '(choice (const :tag "Keep window" keep)
 		 (const :tag "Split current window vertically" split)
 		 (const :tag "Split message window vertically" msg-split)


### PR DESCRIPTION
Add support for horizontally split draft buffer window:  split-horiz

These changes add a new token for use with `wl-draft-buffer-style' and `wl-draft-reply-buffer-style`:  `split-horiz', which, as its name suggests, will split the message window horizontally instead of vertically like `split' does.  This style of window layout can be more convenient and space-efficient for users of wide screens.
