### PR TITLE
Use `window-deletable-p' to check if window is deletable.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2019-06-28  Erik Hetzner  <egh@e6h.org>
+
+	* wl-util.wl (wl-window-deletable-p): Add function.
+
+	* wl-addrmgr.wl (wl-addrmgr-quit-yes): Use `wl-window-deletable-p'
+	to check if window is deletable.
+
+	* wl-draft.wl (wl-draft-hide): Likewise.
+
 2018-11-17  Kazuhiro Ito  <kzhr@d1.dion.ne.jp>
 
 	* doc/wl.texi (Variables of Draft Mode): Update descriptions of

--- a/wl/wl-addrmgr.el
+++ b/wl/wl-addrmgr.el
@@ -399,7 +399,7 @@ Return nil if no ADDRESS exists."
 	     (buffer-live-p draft-buffer)
 	     (null (get-buffer-window draft-buffer 'visible)))
 	(switch-to-buffer draft-buffer)
-      (unless (one-window-p)
+      (if (wl-window-deletable-p)
 	(delete-window)))
     (kill-buffer wl-addrmgr-buffer-name)
     (if (and draft-buffer (not (one-window-p)))

--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -756,7 +756,7 @@ or `wl-draft-reply-with-argument-list' if WITH-ARG argument is non-nil."
 	  ;; hide draft frame
 	  (delete-frame)
 	;; hide draft window
-	(or (one-window-p)
+	(if (wl-window-deletable-p)
 	    (delete-window))
 	;; stay folder window if required
 	(when wl-stay-folder-window

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -3871,9 +3871,9 @@ Return non-nil if the mark is updated"
 	;; hide your folder window
 	(if (and (not wl-stay-folder-window)
 		 (setq fld-buf (get-buffer wl-folder-buffer-name)))
-	    (if (setq fld-win (get-buffer-window fld-buf))
-		(unless (one-window-p fld-win)
-		  (delete-window fld-win))))))
+            (if (setq fld-buf (get-buffer wl-folder-buffer-name))
+	        (if (setq fld-win (get-buffer-window fld-buf))
+	            (delete-window fld-win))))))
      ((eq arg 'off)
       (wl-delete-all-overlays)
       (setq wl-summary-buffer-disp-msg nil)

--- a/wl/wl-util.el
+++ b/wl/wl-util.el
@@ -1009,6 +1009,12 @@ that `read' can handle, whenever this is possible."
 	   (with-current-buffer src
 	     (symbol-value variable))))))
 
+(defsubst wl-window-deletable-p ()
+  "Return t if selected window can be safely deleted from its frame."
+  (if (fboundp 'window-deletable-p)
+      (window-deletable-p)
+    (not (one-window-p))))
+      
 ;;; Search Condition
 (defun wl-search-condition-fields ()
   (let ((denial-fields


### PR DESCRIPTION
Fixes a problem with using `one-window-p' and side windows. The last
non-side window cannot be deleted but `one-window-p' will return `nil'
when there is a side window and a non-side window.

See https://github.com/Alexander-Miller/treemacs/issues/460