### PR TITLE
use ?\s instead of ?(whitespace)

### DIFF
--- a/utils/ptexinfmt.el
+++ b/utils/ptexinfmt.el
@@ -944,7 +944,7 @@ This command is executed when texinfmt sees @item inside @multitable."
 		    (current-column)))))) ;; end of existing line
 	(insert (make-string
 		 (if (> needed-whitespace 0) needed-whitespace 1)
-		 ? )))
+		 ?\s)))
       ;; now, put formatted cell into a rectangle
       (set (intern (concat texinfo-multitable-rectangle-name
 			   (int-to-string table-column)))


### PR DESCRIPTION
`? ` and `?\ ` and `?\s` are return same value.
`?\s` is easier to read and understand.

```elisp
(list ?  ?\  ?\s)
;;=> (32 32 32)
```
ref: https://www.gnu.org/software/emacs/manual/html_mono/elisp.html#Basic-Char-Syntax
