### PR TITLE
fix closing parens position

### DIFF
--- a/elmo/elmo-archive.el
+++ b/elmo/elmo-archive.el
@@ -443,8 +443,7 @@ TYPE specifies the archiver's symbol."
 	(prog1
 	    (elmo-archive-call-method method args)
 	  (if (file-exists-p dummy)
-	      (delete-file dummy)))
-	))))
+	      (delete-file dummy)))))))
 
 (luna-define-method elmo-folder-delete ((folder elmo-archive-folder))
   (let ((msgs (and (elmo-folder-exists-p folder)
@@ -830,8 +829,7 @@ TYPE specifies the archiver's symbol."
 	 msgs))
       (throw 'done
 	     (or (not rest)
-		 (elmo-archive-call-process prog (append args rest))))
-      )))
+		 (elmo-archive-call-process prog (append args rest)))))))
 
 (defsubst elmo-archive-article-exists-p (arc msg type)
   (if (not elmo-archive-check-existance-strict)
@@ -858,8 +856,7 @@ TYPE specifies the archiver's symbol."
 	 (exec (elmo-archive-get-method 'tgz exec-type))
 	 (suffix (elmo-archive-get-suffix 'tgz))
 	 (tar-suffix (elmo-archive-get-suffix 'tar))
-	 arc-tar ret-val
-	 )
+	 arc-tar ret-val)
     (when (null (and decompress compress exec))
       (ding)
       (error "WARNING: special method undefined: %s of %s"

--- a/elmo/elmo-imap4.el
+++ b/elmo/elmo-imap4.el
@@ -2248,8 +2248,7 @@ Return nil if no complete line has arrived."
                  (elmo-imap4-mailbox
                   (elmo-imap4-folder-mailbox-internal folder)))))
         (elmo-imap4-session-set-current-mailbox-internal session nil)
-        (elmo-imap4-session-set-current-mailbox-size-internal session nil)
-        )
+        (elmo-imap4-session-set-current-mailbox-size-internal session nil))
       (elmo-msgdb-delete-path folder)
       t)))
 
@@ -2744,8 +2743,7 @@ time."
                 session mailbox)
              (and session
                   (elmo-imap4-session-set-current-mailbox-internal
-                   session nil))
-            ))
+                   session nil))))
           (error
            (if (elmo-imap4-response-ok-p response)
                (elmo-imap4-session-set-current-mailbox-internal

--- a/elmo/elmo-nntp.el
+++ b/elmo/elmo-nntp.el
@@ -1072,8 +1072,7 @@ Returns a list of cons cells like (NUMBER . VALUE)"
 	    result (elmo-sort-uniq-number-list
 		    (nconc result
 			   (elmo-nntp-search-internal
-			    folder (nth 2 condition) from-msgs))
-		    ))))))
+			    folder (nth 2 condition) from-msgs))))))))
 
 (defun elmo-nntp-use-server-search-p (condition)
   (if (vectorp condition)
@@ -1342,8 +1341,7 @@ Returns a list of cons cells like (NUMBER . VALUE)"
 (luna-define-method elmo-folder-close-internal ((folder elmo-nntp-folder))
 ;;    1.2. In elmo-folder-close, `temp-crosses' slot is cleared,
   (elmo-nntp-folder-set-temp-crosses-internal folder nil)
-  (elmo-nntp-folder-set-reads-internal folder nil)
-  )
+  (elmo-nntp-folder-set-reads-internal folder nil))
 
 (defun elmo-nntp-folder-update-crosspost-message-alist (folder numbers)
 ;;    1.3. In elmo-folder-flag-as-read, move crosspost entry

--- a/elmo/elmo-rss.el
+++ b/elmo/elmo-rss.el
@@ -50,8 +50,7 @@
 (eval-and-compile
   (luna-define-class elmo-rss-folder (elmo-map-folder)
                      (url downloaded entries children))
-  (luna-define-internal-accessors 'elmo-rss-folder)
-  )
+  (luna-define-internal-accessors 'elmo-rss-folder))
 
 (defcustom elmo-rss-use-raw-utf8-in-headers nil
   "*Whether to use raw UTF-8 in headers of RSS messages.

--- a/elmo/elmo-util.el
+++ b/elmo/elmo-util.el
@@ -75,8 +75,7 @@ Buffer's multibyteness is ignored."
     "Encode the STRING as MIME CHARSET.
 Buffer's multibyteness is ignored."
     (elmo-with-enable-multibyte
-      (encode-mime-charset-string string charset lbt))))
- )
+      (encode-mime-charset-string string charset lbt)))))
 
 (defun elmo-base64-encode-string (_string &optional _no-line-break))
 (defun elmo-base64-decode-string (_string))
@@ -461,8 +460,7 @@ When NO-NODIFY is non-nil, dont' modify STRING and return new string."
 	(as-binary-output-file
 	 (insert string)
 	 (write-region (point-min) (point-max)
-		       filename nil 'no-msg))
-	)))
+		       filename nil 'no-msg)))))
 
 (defun elmo-max-of-list (nlist)
   (apply #'max 0 nlist))

--- a/elmo/elmo.el
+++ b/elmo/elmo.el
@@ -961,8 +961,7 @@ If optional argument IF-EXISTS is nil, load on demand.
    folder
    (if numbers (apply #'max numbers) 0)
 ;;;   (length num-db)
-   nil
-   ))
+   nil))
 
 (defun elmo-folder-get-info-max (folder)
   "Return max number of FODLER from folder info."

--- a/tests/test-elmo-date.el
+++ b/tests/test-elmo-date.el
@@ -40,8 +40,7 @@
    ;; [RFC5322] Appendix A.1.3.
    (equal '(-424 63838)
 	  (elmo-time-parse-date-string
-	   "Date: Thu, 13 Feb 1969 23:32:54 -0330")))
-)
+	   "Date: Thu, 13 Feb 1969 23:32:54 -0330"))))
 
 (luna-define-method test-elmo-time-parse-date-string-2 ((case test-elmo-date))
   "Obsolete Date: format"

--- a/tests/test-elmo-util.el
+++ b/tests/test-elmo-util.el
@@ -44,8 +44,7 @@
      (equal list
 	    (elmo-object-load test-elmo-temoporary-file)))))
 
-(luna-define-method test-elmo-save-string-1 ((case test-elmo-util))
-  )
+(luna-define-method test-elmo-save-string-1 ((case test-elmo-util)))
 
 ;; list functions
 (luna-define-method test-elmo-uniq-list-1 ((case test-elmo-util))

--- a/tests/test-utf7.el
+++ b/tests/test-utf7.el
@@ -12,8 +12,7 @@
      (string (make-char 'japanese-jisx0208 70 124)
 	     (make-char 'japanese-jisx0208 75 92)
 	     (make-char 'japanese-jisx0208 56 108)
-	     ?A
-	     )))))
+	     ?A)))))
 
 (luna-define-method test-utf7-encode-string-smiling-face ((case test-utf7))
   (lunit-assert

--- a/tests/test-wl-address.el
+++ b/tests/test-wl-address.el
@@ -8,12 +8,10 @@
   (lunit-assert
    (string=
     "m-sakura@example.org"
-    (wl-address-header-extract-address "Mine Sakurai <m-sakura@example.org>")
-    )))
+    (wl-address-header-extract-address "Mine Sakurai <m-sakura@example.org>"))))
 
 (luna-define-method test-wl-address-header-extract-address-2 ((case test-wl-address))
   (lunit-assert
    (string=
     "m-sakura@example.org"
-    (wl-address-header-extract-address "m-sakura@example.org (Mine Sakurai)")
-    )))
+    (wl-address-header-extract-address "m-sakura@example.org (Mine Sakurai)"))))

--- a/utils/ssl.el
+++ b/utils/ssl.el
@@ -81,8 +81,7 @@ This means a directory of pem encoded certificates with hash symlinks."
     "-host" host
     "-port" service
     "-verify" (int-to-string ssl-certificate-verification-policy)
-    "-CApath" ssl-certificate-directory
-    )
+    "-CApath" ssl-certificate-directory)
   "*Arguments that should be passed to the program `ssl-program-name'.
 This should be used if your SSL program needs command line switches to
 specify any behaviour (certificate file locations, etc).

--- a/utils/wl-complete.el
+++ b/utils/wl-complete.el
@@ -35,8 +35,7 @@
     ("Return-Receipt-To:" . wl-addrbook-complete-address)
     ("Newsgroups:" . wl-complete-newsgroups)
     ("Followup-To:" . wl-complete-newsgroups)
-    ("Fcc:"      . wl-complete-folder)
-    )
+    ("Fcc:"      . wl-complete-folder))
   "*Completion function alist concerned with the key.")
 
 (defvar wl-field-circular-completion-switch

--- a/wl/wl-acap.el
+++ b/wl/wl-acap.el
@@ -211,8 +211,7 @@ If nil, default acap port is used."
 						(decode-coding-string
 						 (cadr x)
 						 wl-acap-coding-system)
-						"\""))
-					 ))))))))
+						"\""))))))))))
 			    (t 'wl-acap-ignored))))
 		       settings)))
 	;; Setup options.

--- a/wl/wl-draft.el
+++ b/wl/wl-draft.el
@@ -154,8 +154,7 @@ e.g.
     [wl-draft-kill
      wl-draft-kill t "Kill Current Draft"]
     [wl-draft-save-and-exit
-     wl-draft-save-and-exit t "Save Draft and Exit"]
-    )
+     wl-draft-save-and-exit t "Save Draft and Exit"])
   "The Draft buffer toolbar.")
 
 (eval-when-compile
@@ -1068,8 +1067,7 @@ Optional argument COLUMN is start-position of the field."
 	  (setq lal (cdr ret))
 	  (while (and (setq ret (std11-parse-ascii-token lal))
 		      (string-equal (cdr (assq 'specials (car ret))) ",")
-		      (setq ret (std11-parse-address (cdr ret)))
-		      )
+		      (setq ret (std11-parse-address (cdr ret))))
 	    (setq dest (cons (car ret) dest))
 	    (setq lal (cdr ret)))
 	  (while (eq 'spaces (car (car lal)))
@@ -1960,8 +1958,7 @@ If KILL-WHEN-DONE is non-nil, current draft buffer is killed"
 	 ;;
 	 ((not field))
 	 (t
-	  (debug))
-	 )))
+	  (debug)))))
       (setq halist (cdr halist)))))
 
 (defun wl-draft-prepare-edit ()
@@ -2062,8 +2059,7 @@ If KILL-WHEN-DONE is non-nil, current draft buffer is killed"
 	'wl-draft-insert-x-face-field-here) ;; allow nil
    mail-default-headers
    ;; check \n at th end of line for `mail-default-headers'
-   'wl-draft-check-new-line
-   ))
+   'wl-draft-check-new-line))
 
 (defun wl-draft-insert-mail-header-separator (&optional delimline)
   (save-excursion

--- a/wl/wl-expire.el
+++ b/wl/wl-expire.el
@@ -434,8 +434,7 @@ Refile to archive folder followed message date."
 			  wl-expire-archive-get-folder-function
 			  folder
 			  wl-expire-archive-date-folder-name-fmt
-			  dst-folder-expand
-			  ))
+			  dst-folder-expand))
 	 (dst-folder-base (car dst-folder-fmt))
 	 (dst-folder-fmt (cdr dst-folder-fmt))
 	 (refile-func (if no-delete

--- a/wl/wl-fldmgr.el
+++ b/wl/wl-fldmgr.el
@@ -350,8 +350,7 @@ return value is diffs '(-new -unread -all)."
 	  (setcdr (cdr entity) (list flist unsubscribes))
 	  (when access
 	    (wl-fldmgr-add-modified-access-list group))
-	  t
-	  ))))))
+	  t))))))
 
 ;; usage:
 ;; (wl-add-entity '(("Desktop") ("ML") "ml/wl") '("+ml/new") wl-folder-entity 12)

--- a/wl/wl-folder.el
+++ b/wl/wl-folder.el
@@ -124,8 +124,7 @@
     "----"
     ["Save Current Status"  wl-save t]
     ["Update Status"        wl-status-update t]
-    ["Exit"                 wl-exit t]
-    ))
+    ["Exit"                 wl-exit t]))
 
 (defun wl-folder-setup-mouse ()
   (define-key wl-folder-mode-map [mouse-2] 'wl-folder-click)
@@ -1625,8 +1624,7 @@ Entering Folder mode calls the value of `wl-folder-mode-hook'."
     (let ((inhibit-read-only t)
 	  (buffer-read-only nil)
 	  (flist (nth 2 entity))
-	  (as-opened (cdr (assoc (car entity) wl-folder-group-alist)))
-	  )
+	  (as-opened (cdr (assoc (car entity) wl-folder-group-alist))))
       (if as-opened
 	  (let (update-flist flist-unsub new-flist)
 	    (when (and (eq (cadr entity) 'access)
@@ -1674,8 +1672,7 @@ Entering Folder mode calls the value of `wl-folder-mode-hook'."
 	    (buffer-read-only nil)
 	    (flist (nth 2 entity))
 	    (as-opened (cdr (assoc (car entity) wl-folder-group-alist)))
-	    beg
-	    )
+	    beg)
 ;;;	(insert indent "[" (if as-opened "-" "+") "]" (car entity) "\n")
 ;;;	(save-excursion (forward-line -1)
 ;;;			(wl-highlight-folder-current-line))
@@ -2022,8 +2019,7 @@ Entering Folder mode calls the value of `wl-folder-mode-hook'."
 	wl-folder-newsgroups-hashtb nil
 	wl-fldmgr-cut-entity-list nil
 	wl-fldmgr-modified nil
-	wl-fldmgr-modified-access-list nil
-	)
+	wl-fldmgr-modified-access-list nil)
   (when (boundp 'wl-score-cache)
     (setq wl-score-cache nil)))
 
@@ -3038,8 +3034,7 @@ Call `wl-summary-write-current-folder' with current folder name."
     [wl-folder-empty-trash
      wl-folder-empty-trash t "Empty Trash"]
     [wl-exit
-     wl-exit t "Quit Wanderlust"]
-    )
+     wl-exit t "Quit Wanderlust"])
   "The Folder buffer toolbar.")
 
 (defun wl-e21-setup-folder-toolbar ()

--- a/wl/wl-message.el
+++ b/wl/wl-message.el
@@ -965,8 +965,7 @@ Returns non-nil if bottom of message."
     [wl-message-play-content
      wl-message-play-content t "Play Content"]
     [wl-message-extract-content
-     wl-message-extract-content t "Extract Content"]
-    )
+     wl-message-extract-content t "Extract Content"])
   "The Message buffer toolbar.")
 
 (defun wl-e21-setup-message-toolbar ()

--- a/wl/wl-mime.el
+++ b/wl/wl-mime.el
@@ -839,8 +839,7 @@ With ARG, ask destination folder."
 				       wl-temporary-file-directory)
 				   nil nil
 				   (or (mime-entity-safe-filename entity)
-				       ".")
-				    ))))
+				       ".")))))
     (while (file-directory-p filename)
       (setq filename (read-file-name "Please set filename (not directory): "
 				     filename)))

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -75,8 +75,7 @@
     [wl-summary-forward
      wl-summary-forward t "Forward Current Message"]
     [wl-summary-exit
-     wl-summary-exit t "Exit Current Summary"]
-    )
+     wl-summary-exit t "Exit Current Summary"])
   "The Summary buffer toolbar.")
 
 (defun wl-e21-setup-summary-toolbar ()
@@ -324,8 +323,7 @@ See also variable `wl-use-petname'."
      ["Enter the message" wl-summary-jump-to-current-message t]
      ["Pipe message" wl-summary-pipe-message t]
      ["Print message" wl-summary-print-message t]
-     ["View raw message" wl-summary-display-raw t]
-     )
+     ["View raw message" wl-summary-display-raw t])
     ("Thread Operation"
      ["Open or Close" wl-thread-open-close (eq wl-summary-buffer-view 'thread)]
      ["Open all"     wl-thread-open-all (eq wl-summary-buffer-view 'thread)]

--- a/wl/wl.el
+++ b/wl/wl.el
@@ -790,8 +790,7 @@ Entering Plugged mode calls the value of `wl-plugged-mode-hook'."
 	  (wl-message-id-domain
 	   "`wl-message-id-domain' seems to be a local hostname.")
 	  (t
-	   "Please set `wl-message-id-domain' to get valid Message-ID."))))
-      ))
+	   "Please set `wl-message-id-domain' to get valid Message-ID."))))))
 
   ;; folders
   (when (not no-check-folder)
@@ -976,8 +975,7 @@ If ARG (prefix argument) is specified, folder checkings are skipped."
      ("wl-draft" wl-draft-rename-saved-config)
      ("wl-qs" :interactive t
       wl-quicksearch-goto-search-folder-wrapper)
-     ("wl-spam" wl-spam-save-status)
-     )))
+     ("wl-spam" wl-spam-save-status))))
 
 ;; for backward compatibility
 (defalias 'wl-summary-from-func-petname 'wl-summary-default-from)


### PR DESCRIPTION
Fix closing parens position.
[Package-lint](https://github.com/purcell/package-lint) warns your package
> Closing parens should not be wrapped onto new lines. (emacs-lisp-package)

I eval below sexp in dired (depends `visual-regexp`).

``` emacs-lisp
(while (dired-get-filename nil 'no-error)
  (let ((file (dired-get-filename)))
    (with-temp-file file
      (insert-file-contents file)

      (while (not (= 0 (vr/replace "^(?!.*;)(.*)\\n[\\s\\t]*(\\)+)" "\\1\\2" (point-min) (point-max))))))
    (message file)
    (dired-next-line 1)))
```