### PR TITLE
Introduce wl-summary-descending-order

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -217,7 +217,7 @@ Wanderlust NEWS -- User-visible changes in Wanderlust.
    are now toggle key.
    Now you can cite messages displayed by 'M'.
 
-** Now you can sort summary lines into descending order.
+** Now you can sort summary lines into reverse order.
 
 ** Abbreviate too long header extended to lines in message buffer.
 

--- a/doc/wl-ja.texi
+++ b/doc/wl-ja.texi
@@ -4225,11 +4225,11 @@ Non-nil なら、@samp{^L} で改ページしてメッセージを表示しま�
 新規に作成されたサマリの状態をスレッド表示なら @code{'thread}、
 番号順なら @code{'sequence} のいずれかで指定します。
 
-@item wl-summary-descending-order
-@vindex wl-summary-descending-order
-初期設定は @code{nil}。
-Non-nil ならサマリバッファのメッセージを降順に並べます。
-一つのスレッド中のメッセージの順序はこの値に関わらず常に昇順です。
+@item wl-summary-order
+@vindex wl-summary-order
+初期設定は @code{'ascending}。
+@code{'descending} ならサマリバッファのメッセージを降順に並べます。
+各スレッド中のメッセージの順序はこの値に関わらず常に昇順です。
 
 @item wl-summary-use-frame
 @vindex wl-summary-use-frame

--- a/doc/wl-ja.texi
+++ b/doc/wl-ja.texi
@@ -4225,6 +4225,12 @@ Non-nil なら、@samp{^L} で改ページしてメッセージを表示しま�
 新規に作成されたサマリの状態をスレッド表示なら @code{'thread}、
 番号順なら @code{'sequence} のいずれかで指定します。
 
+@item wl-summary-descending-order
+@vindex wl-summary-descending-order
+初期設定は @code{nil}。
+Non-nil ならサマリバッファのメッセージを降順に並べます。
+一つのスレッド中のメッセージの順序はこの値に関わらず常に昇順です。
+
 @item wl-summary-use-frame
 @vindex wl-summary-use-frame
 初期設定は @code{nil}。

--- a/doc/wl.texi
+++ b/doc/wl.texi
@@ -4261,12 +4261,12 @@ The initial setting is @code{'thread}.
 The default state for newly created summary. You can set either
 @code{'thread} for thread view or @code{'sequence} for sequential view.
 
-@item wl-summary-descending-order
-@vindex wl-summary-descending-order
-The initial setting is @code{nil}.
-If non-nil, messages are listed in descending order in summary buffer.
+@item wl-summary-order
+@vindex wl-summary-order
+The initial setting is @code{'ascending}.
+Specify order of messages in summary buffer.
 Note that messages in a thread are always listed in ascending order
-even if this value is non-nil.
+even if this value is @code{'descending}.
 
 @item wl-summary-use-frame
 @vindex wl-summary-use-frame

--- a/doc/wl.texi
+++ b/doc/wl.texi
@@ -3668,7 +3668,7 @@ last:NUM         Move to the filter folder(partial filter).
 Sort summary order.
 You can sort by @samp{date}, @samp{from}, @samp{number}, @samp{subject},
 @samp{size} and @samp{list-info}.
-With prefix argument, sort summary lines into descending order.
+With prefix argument, sort summary lines into reverse order.
 (@code{wl-summary-sort})
 
 @item T

--- a/doc/wl.texi
+++ b/doc/wl.texi
@@ -4261,6 +4261,13 @@ The initial setting is @code{'thread}.
 The default state for newly created summary. You can set either
 @code{'thread} for thread view or @code{'sequence} for sequential view.
 
+@item wl-summary-descending-order
+@vindex wl-summary-descending-order
+The initial setting is @code{nil}.
+If non-nil, messages are listed in descending order in summary buffer.
+Note that messages in a thread are always listed in ascending order
+even if this value is non-nil.
+
 @item wl-summary-use-frame
 @vindex wl-summary-use-frame
 The initial setting is @code{nil}.

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -2094,9 +2094,10 @@ This function is defined for `window-scroll-functions'"
       (wl-summary-update-modeline)
       ;;
       (unless unset-cursor
-	(goto-char (point-min))
-	(if (not wl-summary-descending-order)
-	    (progn
+	(goto-char (if wl-summary-descending-order (point-max) (point-min)))
+	(if (not (if wl-summary-descending-order (wl-summary-cursor-up t)
+                   (wl-summary-cursor-down t)))
+	    (if wl-summary-descending-order (goto-char (point-min))
 	      (goto-char (point-max))
 	      (forward-line -1))
 	  (when (and wl-summary-highlight
@@ -2613,8 +2614,11 @@ If ARG, without confirm."
        (wl-summary-create-line entity nil nil
 			       (elmo-message-status folder number)))
       (setq wl-summary-buffer-number-list
-	    (wl-append wl-summary-buffer-number-list
-		       (list (elmo-message-entity-number entity))))
+	    (if wl-summary-descending-order
+                (cons (elmo-message-entity-number entity)
+                      wl-summary-buffer-number-list)
+              (wl-append wl-summary-buffer-number-list
+		         (list (elmo-message-entity-number entity)))))
       nil)))
 
 (defun wl-summary-default-subject-filter (subject)
@@ -3620,8 +3624,7 @@ Return non-nil if the mark is updated"
       (funcall wl-summary-buffer-next-message-function num direction hereto)
     (let ((cur-spec (cdr (assq wl-summary-move-order
 			       wl-summary-move-spec-alist)))
-	  (nums (memq num (if (eq direction
-                                  (if wl-summary-descending-order 'down 'up))
+	  (nums (memq num (if (eq direction 'up)
 			      (reverse wl-summary-buffer-number-list)
 			    wl-summary-buffer-number-list)))
 	  flagged-list nums2)

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -1048,7 +1048,7 @@ Entering Folder mode calls the value of `wl-summary-mode-hook'."
 	  `(lambda (&optional reverse)
 	     ,(format "\
 Sort summary lines into the order by %s.
-If optional argument REVERSE is non-nil, sort into descending order.
+If optional argument REVERSE is non-nil, sort into reverse order.
 
 This function is defined by `wl-summary-define-sort-command'." sort-by)
 	     (interactive "P")
@@ -1152,7 +1152,7 @@ This function is defined by `wl-summary-define-sort-command'." sort-by)
     (wl-summary-set-message-modified)
     (wl-summary-count-unread)
     (wl-summary-update-modeline)
-    (goto-char (point-max))
+    (goto-char (if wl-summary-descending-order (point-min) (point-max)))
     (forward-line -1)
     (set-buffer-modified-p nil)))
 
@@ -1918,7 +1918,7 @@ This function is defined for `window-scroll-functions'"
     (elmo-progress-notify 'wl-summary-insert-line)))
 
 (defun wl-summary-sort (reverse)
-  "Sort summary lines into the selected order; argument means descending order."
+  "Sort summary lines into the selected order; argument means reverse order."
   (interactive "P")
   (let ((default-value (symbol-name wl-summary-default-sort-spec)))
     (wl-summary-rescan
@@ -2095,7 +2095,7 @@ This function is defined for `window-scroll-functions'"
       ;;
       (unless unset-cursor
 	(goto-char (point-min))
-	(if (not (wl-summary-cursor-down t))
+	(if (not wl-summary-descending-order)
 	    (progn
 	      (goto-char (point-max))
 	      (forward-line -1))
@@ -2608,7 +2608,7 @@ If ARG, without confirm."
     (let ((inhibit-read-only t)
 	  (number (elmo-message-entity-number entity))
 	  buffer-read-only)
-      (goto-char (point-max))
+      (goto-char (if wl-summary-descending-order (point-min) (point-max)))
       (wl-summary-insert-line
        (wl-summary-create-line entity nil nil
 			       (elmo-message-status folder number)))
@@ -2803,7 +2803,7 @@ If ARG, without confirm."
     (cond
      ((or (not parent-id)
 	  (string= this-id parent-id))
-      (goto-char (point-max))
+      (goto-char (if wl-summary-descending-order (point-min) (point-max)))
       (beginning-of-line)
       (setq insert-line t))
      ;; parent already exists in buffer.
@@ -3620,7 +3620,8 @@ Return non-nil if the mark is updated"
       (funcall wl-summary-buffer-next-message-function num direction hereto)
     (let ((cur-spec (cdr (assq wl-summary-move-order
 			       wl-summary-move-spec-alist)))
-	  (nums (memq num (if (eq direction 'up)
+	  (nums (memq num (if (eq direction
+                                  (if wl-summary-descending-order 'down 'up))
 			      (reverse wl-summary-buffer-number-list)
 			    wl-summary-buffer-number-list)))
 	  flagged-list nums2)

--- a/wl/wl-summary.el
+++ b/wl/wl-summary.el
@@ -1152,7 +1152,7 @@ This function is defined by `wl-summary-define-sort-command'." sort-by)
     (wl-summary-set-message-modified)
     (wl-summary-count-unread)
     (wl-summary-update-modeline)
-    (goto-char (if wl-summary-descending-order (point-min) (point-max)))
+    (goto-char (if (eq wl-summary-order 'descending) (point-min) (point-max)))
     (forward-line -1)
     (set-buffer-modified-p nil)))
 
@@ -2094,10 +2094,11 @@ This function is defined for `window-scroll-functions'"
       (wl-summary-update-modeline)
       ;;
       (unless unset-cursor
-	(goto-char (if wl-summary-descending-order (point-max) (point-min)))
-	(if (not (if wl-summary-descending-order (wl-summary-cursor-up t)
+	(goto-char (if (eq wl-summary-order 'descending) (point-max)
+                     (point-min)))
+	(if (not (if (eq wl-summary-order 'descending) (wl-summary-cursor-up t)
                    (wl-summary-cursor-down t)))
-	    (if wl-summary-descending-order (goto-char (point-min))
+	    (if (eq wl-summary-order 'descending) (goto-char (point-min))
 	      (goto-char (point-max))
 	      (forward-line -1))
 	  (when (and wl-summary-highlight
@@ -2609,12 +2610,12 @@ If ARG, without confirm."
     (let ((inhibit-read-only t)
 	  (number (elmo-message-entity-number entity))
 	  buffer-read-only)
-      (goto-char (if wl-summary-descending-order (point-min) (point-max)))
+      (goto-char (if (eq wl-summary-order 'descending) (point-min) (point-max)))
       (wl-summary-insert-line
        (wl-summary-create-line entity nil nil
 			       (elmo-message-status folder number)))
       (setq wl-summary-buffer-number-list
-	    (if wl-summary-descending-order
+	    (if (eq wl-summary-order 'descending)
                 (cons (elmo-message-entity-number entity)
                       wl-summary-buffer-number-list)
               (wl-append wl-summary-buffer-number-list
@@ -2807,7 +2808,7 @@ If ARG, without confirm."
     (cond
      ((or (not parent-id)
 	  (string= this-id parent-id))
-      (goto-char (if wl-summary-descending-order (point-min) (point-max)))
+      (goto-char (if (eq wl-summary-order 'descending) (point-min) (point-max)))
       (beginning-of-line)
       (setq insert-line t))
      ;; parent already exists in buffer.

--- a/wl/wl-thread.el
+++ b/wl/wl-thread.el
@@ -97,11 +97,16 @@
 (defsubst wl-thread-entity-insert-as-top (entity)
   (when (and entity
 	     (wl-thread-entity-get-number entity))
-    (wl-append wl-thread-entity-list (list (car entity)))
+    (if wl-summary-descending-order
+        (setq wl-thread-entity-list (cons (car entity) wl-thread-entity-list))
+      (wl-append wl-thread-entity-list (list (car entity))))
     (setq wl-thread-entities (cons entity wl-thread-entities))
     (setq wl-summary-buffer-number-list
-	  (nconc wl-summary-buffer-number-list
-		 (list (wl-thread-entity-get-number entity))))
+	  (if wl-summary-descending-order
+              (cons (wl-thread-entity-get-number entity)
+                    wl-summary-buffer-number-list)
+            (nconc wl-summary-buffer-number-list
+                   (list (wl-thread-entity-get-number entity)))))
     (wl-thread-set-entity entity)))
 
 (defsubst wl-thread-entity-insert-as-children (to entity)
@@ -860,7 +865,6 @@ Message is inserted to the summary buffer."
         "Inserting message"
       (wl-delete-all-overlays)
       (dolist (e wl-thread-entity-list)
-        (if wl-summary-descending-order (goto-char (point-min)))
         (wl-thread-insert-entity
          0
          (wl-thread-get-entity e)
@@ -1114,7 +1118,9 @@ Message is inserted to the summary buffer."
 	       (or (null parent)
 		   (/= parent-number (elmo-message-entity-number parent))))))
 	;; insert as top
-	(wl-append wl-thread-entity-list (list number))
+	(if wl-summary-descending-order
+            (setq wl-thread-entity-list (cons number wl-thread-entity-list))
+          (wl-append wl-thread-entity-list (list number)))
 	(wl-thread-entity-set-linked entity nil))
 
       ;; update my thread

--- a/wl/wl-thread.el
+++ b/wl/wl-thread.el
@@ -860,6 +860,7 @@ Message is inserted to the summary buffer."
         "Inserting message"
       (wl-delete-all-overlays)
       (dolist (e wl-thread-entity-list)
+        (if wl-summary-descending-order (goto-char (point-min)))
         (wl-thread-insert-entity
          0
          (wl-thread-get-entity e)

--- a/wl/wl-thread.el
+++ b/wl/wl-thread.el
@@ -97,12 +97,12 @@
 (defsubst wl-thread-entity-insert-as-top (entity)
   (when (and entity
 	     (wl-thread-entity-get-number entity))
-    (if wl-summary-descending-order
+    (if (eq wl-summary-order 'descending)
         (setq wl-thread-entity-list (cons (car entity) wl-thread-entity-list))
       (wl-append wl-thread-entity-list (list (car entity))))
     (setq wl-thread-entities (cons entity wl-thread-entities))
     (setq wl-summary-buffer-number-list
-	  (if wl-summary-descending-order
+	  (if (eq wl-summary-order 'descending)
               (cons (wl-thread-entity-get-number entity)
                     wl-summary-buffer-number-list)
             (nconc wl-summary-buffer-number-list
@@ -1118,7 +1118,7 @@ Message is inserted to the summary buffer."
 	       (or (null parent)
 		   (/= parent-number (elmo-message-entity-number parent))))))
 	;; insert as top
-	(if wl-summary-descending-order
+	(if (eq wl-summary-order 'descending)
             (setq wl-thread-entity-list (cons number wl-thread-entity-list))
           (wl-append wl-thread-entity-list (list number)))
 	(wl-thread-entity-set-linked entity nil))

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -192,6 +192,11 @@ If no match, `wl-summary-default-view' is used."
 			       (const :tag "Sequential" sequence))))
   :group 'wl-summary)
 
+(defcustom wl-summary-descending-order nil
+  "Messages are listed in descending order in summary buffer if non-nil."
+  :type 'boolean
+  :group 'wl-summary)
+
 (defvar wl-summary-mode-line-format-spec-alist
   '((?f (if (memq 'modeline wl-use-folder-petname)
 	    (wl-folder-get-petname (elmo-folder-name-internal

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -193,7 +193,9 @@ If no match, `wl-summary-default-view' is used."
   :group 'wl-summary)
 
 (defcustom wl-summary-descending-order nil
-  "Messages are listed in descending order in summary buffer if non-nil."
+  "Messages are listed in descending order in summary buffer if non-nil.
+Note that messages in a thread are always listed in ascending order
+even if this value is non-nil."
   :type 'boolean
   :group 'wl-summary)
 

--- a/wl/wl-vars.el
+++ b/wl/wl-vars.el
@@ -192,11 +192,12 @@ If no match, `wl-summary-default-view' is used."
 			       (const :tag "Sequential" sequence))))
   :group 'wl-summary)
 
-(defcustom wl-summary-descending-order nil
-  "Messages are listed in descending order in summary buffer if non-nil.
+(defcustom wl-summary-order 'ascending
+  "Specify order of messages in summary buffer.
 Note that messages in a thread are always listed in ascending order
-even if this value is non-nil."
-  :type 'boolean
+even if this value is descending."
+  :type '(choice (const :tag "Ascending order" ascending)
+		 (const :tag "Descending order" descending))
   :group 'wl-summary)
 
 (defvar wl-summary-mode-line-format-spec-alist


### PR DESCRIPTION
Hi Ito-san,

First of all, thank you for maintaining Wanderlust which is still awesome Emacs MUA as of today.  I would like to suggest to introduce wl-summary-descending-order to make Wanderlust a little bit align with modern mailers like Gmail, MS Outlook and so on.  This is a higher level concept than reverse sorting.  Meaning, reverse sorting when wl-summary-descending-order t, messages are listed in ascending order.  Hope this makes sense.