### PR TITLE
Revive face for new messages on light background

### DIFF
--- a/wl/wl-highlight.el
+++ b/wl/wl-highlight.el
@@ -401,8 +401,7 @@
   :group 'wl-faces)
 
 (defface wl-highlight-summary-new-face
-  '((((type graphic)
-      (background dark))
+  '((((type graphic))
      (:foreground "tomato"))
     (((type tty)
       (min-colors 16777216))


### PR DESCRIPTION
* wl/wl-highlight.el (wl-highlight-summary-new-face): Define face on
light background graphic.

It seems mistakenly lacked the definition by the commit
<https://github.com/wanderlust/wanderlust/commit/e82886f0fc7b7cc5807fbeeec6a8c28a33a7e502>.
