### PR TITLE
Minor fixes for light background tty

### DIFF
--- a/wl/wl-highlight.el
+++ b/wl/wl-highlight.el
@@ -288,7 +288,6 @@
       (background light))
      (:foreground "color-20" :bold t))
     (((type tty)
-      (min-colors 88)
       (background light))
      (:foreground "black" :bold t)))
   "Face used for displaying contents of unimportant headers."
@@ -1505,7 +1504,6 @@
       (background light))
      (:foreground "color-20" :background "color-62"))
     (((type tty)
-      (min-colors 88)
       (background light))
      (:foreground "black" :background "white")))
   "Face used for displaying demo."


### PR DESCRIPTION
* wl/wl-highlight.el (wl-highlight-message-unimportant-header-contents):
Define face on light background standard color tty.
(wl-highlight-demo-face): Ditto.

The `(min-colors 88)` condition seems duplicated.  It may be for
standard color tty.
