### PR TITLE
Fix `error: (void-function install-file)` for `make install-info`.

### DIFF
--- a/WL-MK
+++ b/WL-MK
@@ -323,6 +323,7 @@
     (install-file infofile DOCDIR INFODIR nil 'overwrite)))
 
 (defun wl-texinfo-install ()
+  (require 'install)
   (cond ((null wl-info-lang))
 	((listp wl-info-lang)
 	 (mapc 'wl-texinfo-install-file wl-info-lang))


### PR DESCRIPTION
* WL-MK (wl-texinfo-install): Require 'install feature.