### PR TITLE
Fix for RAR archive format

### DIFF
--- a/elmo/elmo-archive.el
+++ b/elmo/elmo-archive.el
@@ -147,7 +147,7 @@
      (zoo . "^.*[ \t]%s\\([0-9]+\\)$")
      (tar . "^%s\\([0-9]+\\)$")		; ok
      (tgz . "^%s\\([0-9]+\\)$")		; ok
-     (rar . "^[ \t]%s\\([0-9]+\\)$"))))
+     (rar . "^%s\\([0-9]+\\)$"))))
 
 (defvar elmo-archive-suffix-alist
   '((lha . ".lzh")			; default
@@ -208,7 +208,7 @@
   '((cp       . ("rar" "u" "-m5"))
     (mv       . ("rar" "m" "-m5"))
     (rm       . ("rar" "d"))
-    (ls       . ("rar" "v"))
+    (ls       . ("rar" "lb"))
     (cat      . ("rar" "p" "-inul"))
     (ext      . ("rar" "x"))))
 


### PR DESCRIPTION
The `rar v` output format has been changed long ago that no longer matches the regexp. Change to use `rar lb` which produces content list in format identical to tar.

`rar v` output is like
```
RAR 6.24   Copyright (c) 1993-2023 Alexander Roshal   3 Oct 2023
Registered to ** *

Archive: hp-00000.rar
Details: RAR 5

 Attributes      Size    Packed Ratio    Date    Time   Checksum  Name
----------- ---------  -------- ----- ---------- -----  --------  ----
 -rw-r--r--         0         0   0%  2023-11-02 13:08  00000000  .elmo-archive
 -rw-r--r--      4765      2638  55%  2023-11-02 11:57  741D757D  1
 -rw-r--r--      7161      4074  56%  2023-11-02 11:59  E4A25735  10
 -rw-r--r--      8464      4684  55%  2023-11-02 11:59  F2B17402  11
 -rw-r--r--      6638      3666  55%  2023-11-02 11:59  95F9BE8B  12
 -rw-r--r--      6133      3532  57%  2023-11-02 11:59  1E3A93CB  13
 -rw-r--r--      5881      3345  56%  2023-11-02 11:59  134113BD  14
 -rw-r--r--      7166      3952  55%  2023-11-02 11:57  44587A1C  2
 -rw-r--r--      7191      4369  60%  2023-11-02 11:58  0DBF84B7  3
 -rw-r--r--      6354      3455  54%  2023-11-02 11:58  91651975  4
 -rw-r--r--      8153      4744  58%  2023-11-02 11:58  CD5C6311  5
 -rw-r--r--      5881      3197  54%  2023-11-02 11:58  47781B98  6
 -rw-r--r--      7358      3963  53%  2023-11-02 11:58  92519FA3  7
 -rw-r--r--      5939      3388  57%  2023-11-02 11:59  5B1F5CE6  8
 -rw-r--r--      5844      3298  56%  2023-11-02 11:59  11C3185F  9
----------- ---------  -------- ----- ---------- -----  --------  ----
                92928     52305  56%                              15
```

And the regexp `"^[\t ]%s\\([0-9]+\\)$"` fail to work. `rar lb` produces just
```
.elmo-archive
1
10
11
12
13
14
2
3
4
5
6
7
8
9
```
As for `unzip` seems cannot produce more simple content listing, the logic of archive content listing in `elmo-archive-list-folder-subr` cannot be further simplified.