### PR TITLE
Improve network stability

### DIFF
--- a/elmo/elmo-imap4.el
+++ b/elmo/elmo-imap4.el
@@ -465,26 +465,29 @@ COMMAND is a list of command tokens or a single command token."
 (defun elmo-imap4-read-response (session tag)
   "Read parsed response from SESSION.
 TAG is the tag of the command"
-  (with-current-buffer (process-buffer
-                        (elmo-network-session-process-internal session))
-    (while (not (or (string= tag elmo-imap4-reached-tag)
-                    (elmo-imap4-response-bye-p elmo-imap4-current-response)
-                    (when (elmo-imap4-response-garbage-p
-                           elmo-imap4-current-response)
-                      (message "Garbage response: %s"
-                               (elmo-imap4-response-value
-                                elmo-imap4-current-response
-                                'garbage))
-                      t)))
-      (when (memq (process-status
-                   (elmo-network-session-process-internal session))
-                  '(open run))
-        (accept-process-output (elmo-network-session-process-internal session)
-                               1)))
-    (elmo-imap4-debug "[%s] => %s" (format-time-string "%T") (prin1-to-string elmo-imap4-current-response))
-    (setq elmo-imap4-parsing nil)
-    (elmo-imap4-mailbox-size-update-maybe session elmo-imap4-current-response)
-    elmo-imap4-current-response))
+  (let ((process (elmo-network-session-process-internal session)))
+    (with-current-buffer (process-buffer process)
+      (while (not (or (string= tag elmo-imap4-reached-tag)
+                      (elmo-imap4-response-bye-p elmo-imap4-current-response)
+                      (when (not (memq (process-status process) '(open run)))
+                        (elmo-network-close-session session)
+                        (signal 'elmo-imap4-bye-error "Connection is broken, session is closed"))
+                      (when (elmo-imap4-response-garbage-p
+                             elmo-imap4-current-response)
+                        (message "Garbage response: %s"
+                                 (elmo-imap4-response-value
+                                  elmo-imap4-current-response
+                                  'garbage))
+                        t)))
+        (when (memq (process-status
+                     (elmo-network-session-process-internal session))
+                    '(open run))
+          (accept-process-output (elmo-network-session-process-internal session)
+                                 1)))
+      (elmo-imap4-debug "[%s] => %s" (format-time-string "%T") (prin1-to-string elmo-imap4-current-response))
+      (setq elmo-imap4-parsing nil)
+      (elmo-imap4-mailbox-size-update-maybe session elmo-imap4-current-response)
+      elmo-imap4-current-response)))
 
 (defsubst elmo-imap4-read-untagged (process)
   (with-current-buffer (process-buffer process)


### PR DESCRIPTION
Here a fix for https://github.com/wanderlust/wanderlust/issues/225

Anyway, it has one side effect: it doesn't try to reconnect to IMAP server inside `wl-biff`. Instead it wait until user do it. And status inside C-t aren't actual :(

Thus, I may miss some edge cases.